### PR TITLE
解决rgv不带参会报错。

### DIFF
--- a/rgg
+++ b/rgg
@@ -138,7 +138,7 @@ def linked(s: str, abspath: str, line: int, col: int) -> str:
   return f'\x1b]8;;{url}\x1b\\{s}\x1b]8;;\x1b\\'
 
 class Display:
-  def __init__(self, basepath: str, isatty: bool) -> None:
+  def __init__(self, basepath: str, isatty: bool = False) -> None:
     if isatty:
       if pager := os.environ.get('PAGER'):
         pager_cmd = shlex.split(pager)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/bin/rgv", line 355, in <module>
    view()
  File "/usr/bin/rgv", line 350, in view
    cat(logfile)
  File "/usr/bin/rgv", line 296, in cat
    display = Display(basedir)
TypeError: __init__() missing 1 required positional argument: 'isatty'
```